### PR TITLE
fix command line errors in readme and contributing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following commands are valid in Schedge:
 
 #### Example
 ```sh
-./schedge scrape catalog --year 2020 --term sp --school UA --subject CSCI
+./schedge scrape catalog --year 2020 --semester sp --school UA --subject CSCI
 ```
 The above command will scrape catalog data from Albert website for Computer Science courses at the
 College of Arts and Sciences for the Spring, 2020.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -147,7 +147,7 @@ allow you to query, scrape and parse Albert data. So shall we open the terminal 
 
 ## Build
 - `gradle build`: build the application.
-- `java-jar .build/libs/schedge-all.jar`: test the code.
+- `java -jar .build/libs/schedge.jar`: test the code.
 - `gradle checkFast`: quickly check if the code compiles.
 
 ## Issue


### PR DESCRIPTION
In README.md's example command, we can't have both year and term flag, so change term to semester to get the spring semester.
In Contributing.md, need to add space before -jar flag so it's not interpreted as "java-jar". Then, change name from "schedge-all.jar" to "schedge.jar"