### PR TITLE
Change path to .jar file in .bat script

### DIFF
--- a/schedge.bat
+++ b/schedge.bat
@@ -21,6 +21,6 @@ goto fail
 
 :init
 set CMD_LINE_ARGS=%*
-%JAVA_EXE% "-jar" "%PROJ_DIR%/.build/libs/schedge-all.jar" %CMD_LINE_ARGS%
+%JAVA_EXE% "-jar" "%PROJ_DIR%/.build/libs/schedge.jar" %CMD_LINE_ARGS%
 
 


### PR DESCRIPTION
PR related to #14. Minor issue, but good QOL fix for anyone on Windows. 