### PR TITLE
fix cli's shop enroll missing parameter instruction

### DIFF
--- a/src/main/java/cli/templates/LoginMixin.java
+++ b/src/main/java/cli/templates/LoginMixin.java
@@ -26,7 +26,7 @@ public final class LoginMixin {
     if (user == null) {
       throw new CommandLine.ParameterException(
           spec.commandLine(),
-          "Must provide at least one. Either --term OR --semester AND --year");
+          "Must provide --username AND --pwd");
     }
     return user;
   }


### PR DESCRIPTION
when missing --username and --pwd, we should ask for "usrename" and "pwd" instead of time.