### PR TITLE
Fixing section endpoints

### DIFF
--- a/src/main/java/database/courses/SelectRows.java
+++ b/src/main/java/database/courses/SelectRows.java
@@ -33,15 +33,16 @@ public class SelectRows {
 
     Utils.setArray(sectionIdStmt, registrationNumber, epoch);
     ResultSet rs = sectionIdStmt.executeQuery();
-    ArrayList<Integer> sectionIds = new ArrayList<>();
     if (!rs.next())
       return Stream.empty();
 
     int sectionId = rs.getInt(1);
+    Integer[] intSectionIds = new Integer[]{sectionId};
+    Array sectionIds = conn.createArrayOf("integer", intSectionIds);
     rs.close();
     return selectRows(
         conn, "sections.id = ANY (?) OR sections.associated_with = ANY (?)",
-        sectionId, sectionId);
+        sectionIds, sectionIds);
   }
 
   public static Stream<Row> selectRowsBySectionId(Connection conn, int epoch,


### PR DESCRIPTION
# Description
- Section endpoint were throwing exception when passed registration number.

# Fix
- Just passing an array of integers to the prepared statements instead of just an integer since we are using `Any (?)`