### PR TITLE
Resolve RMP scraping bugs

### DIFF
--- a/src/main/java/database/instructors/UpdateInstructors.java
+++ b/src/main/java/database/instructors/UpdateInstructors.java
@@ -19,7 +19,7 @@ public class UpdateInstructors {
     ResultSet rs = stmt.executeQuery();
     ArrayList<Instructor> instructors = new ArrayList<>();
     while (rs.next()) {
-      instructors.add(new Instructor(rs.getInt("name"), rs.getString("name")));
+      instructors.add(new Instructor(rs.getInt("id"), rs.getString("name")));
     }
     return instructors;
   }
@@ -32,7 +32,7 @@ public class UpdateInstructors {
         conn.prepareStatement("UPDATE instructors SET "
                               + "rmp_rating = ?, rmp_tid  = ? WHERE id = ?");
     GetRatings.getRatings(instructors.iterator(), batchSizeNullable)
-        .filter(rating -> rating.rmpTeacherId != -1)
+        .filter(rating -> rating.rmpTeacherId != -1 && rating.rating != -1.0f)
         .forEach(rating -> {
           try {
             if (Utils

--- a/src/main/java/scraping/GetRatings.java
+++ b/src/main/java/scraping/GetRatings.java
@@ -132,20 +132,20 @@ public final class GetRatings {
           }
 
           return new Rating(id, Integer.parseInt(url),
-                            parseRating(resp.getResponseBody()));
+                            parseRating(resp.getResponseBody(), id));
         });
   }
 
-  private static Float parseRating(String rawData) {
+  private static Float parseRating(String rawData, int id) {
     rawData = rawData.trim();
     if (rawData == null || rawData.equals("")) {
       logger.warn("Got bad data: empty string");
-      return null;
+      return -1.0f;
     }
     Document doc = Jsoup.parse(rawData);
     Element body = doc.selectFirst("div#root");
     if (body == null)
-      return null;
+      return -1.0f;
     Element ratingBody =
         body.selectFirst("div.TeacherInfo__StyledTeacher-ti1fio-1.fIlNyU");
     Element ratingInnerBody = ratingBody.selectFirst("div").selectFirst(
@@ -158,8 +158,9 @@ public final class GetRatings {
     try {
       return Float.parseFloat(ratingValue);
     } catch (NumberFormatException exception) {
-      logger.warn("The instructor exist but having N/A rating");
-      return null;
+      logger.warn("The instructor with id=" + id +
+                  " exists but has an N/A rating");
+      return -1.0f;
     }
   }
 
@@ -187,7 +188,7 @@ public final class GetRatings {
     Elements professors = innerListings.select("li.listing.PROFESSOR");
     for (Element element : professors) {
       String school =
-          element.selectFirst("span.sub").toString(); //<- Bugs at this line
+          element.selectFirst("span.sub").toString(); // <- Bugs at this line
       if (school.contains("New York University") || school.contains("NYU")) {
         return element.selectFirst("a").attr("href").split("=")[1];
       }

--- a/src/main/java/scraping/GetRatings.java
+++ b/src/main/java/scraping/GetRatings.java
@@ -136,7 +136,7 @@ public final class GetRatings {
         });
   }
 
-  private static Float parseRating(String rawData, int id) {
+  private static float parseRating(String rawData, int id) {
     rawData = rawData.trim();
     if (rawData == null || rawData.equals("")) {
       logger.warn("Got bad data: empty string");

--- a/src/main/java/scraping/models/Rating.java
+++ b/src/main/java/scraping/models/Rating.java
@@ -3,10 +3,10 @@ package scraping.models;
 public final class Rating {
   public final int instructorId;
   public final Integer rmpTeacherId;
-  public final Float rating;
+  public final float rating;
 
   // For the sake of simplicity, forget mostHelpful for now
-  public Rating(int instructorId, Integer rmpTeacherId, Float rating) {
+  public Rating(int instructorId, Integer rmpTeacherId, float rating) {
     this.instructorId = instructorId;
     this.rmpTeacherId = rmpTeacherId;
     this.rating = rating;

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -109,6 +109,8 @@ public final class Utils {
       stmt.setFloat(index, (Float)obj);
     } else if (obj instanceof Double) {
       stmt.setDouble(index, (Double)obj);
+    } else if (obj == null) {
+      throw new IllegalArgumentException("object is null");
     } else {
       throw new IllegalArgumentException(
           "type of object is incompatible for object=" + obj.toString());


### PR DESCRIPTION
Sorry for the delay getting this out; this fixes the breaking issues with RMP scraping but since the Duplicate Instructors issue is still unresolved there are still logging statements in the code and further work to be done.

The main issue was the rating being `null` and throwing an `IllegalArgumentException`; this is resolved by returning `-1.0f` when no rating is found. This way we don't have to worry about passing `null` arguments and we can still check if no rating exists by seeing if it is negative.